### PR TITLE
build: Simplify Bazel Usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Test
 on:
   - push
 jobs:
@@ -6,8 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: bazel build --profile /tmp/bazel-profile-build.gz --jobs 8 //...
-      - run: bazel test --jobs 8 //...
+      - run: npm ci
+      - run: npm run build -- --profile /tmp/bazel-profile-build.gz --jobs 8
+      - run: npm test -- --jobs 8
       - name: Upload Bazel profiles
         uses: actions/upload-artifact@v2
         with:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,6 +43,14 @@ pkg_tar(
     ],
 )
 
+filegroup(
+    name = "outputs",
+    srcs = [
+        ":dist",
+        ":parameters",
+    ],
+)
+
 # test diff
 filegroup(
     name = "dist_files",
@@ -127,6 +135,6 @@ genrule(
         "@npm//yargs",
     ],
     outs = ["parameters.yml"],
+    cmd = "$(location //rules:parameters) --output $@ $(locations //specification:openapi3)",
     tools = ["//rules:parameters"],
-    cmd = "$(location //rules:parameters) --output $@ $(locations //specification:openapi3)"  
 )

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The repository makes use of [Bazel](https://bazel.build/) to generate outputs fr
     in the appropriate index.yml file.
 
 3. `npm run responses` (optional)
-    > **Note**: This is an optional step requiring an API key. Set the `WOOSMAP_PUBLIC_API_KEY` and `WOOSMAP_PRIVATE_API_KEY` environmental variable before running. **Hint**: Use a `.bazelrc.user` file at the root of this project.
+    > **Note**: This is an optional step requiring an API key. Set the `WOOSMAP_PUBLIC_API_KEY` and `WOOSMAP_PRIVATE_API_KEY` environmental variable before running.
 
     > **Warning**: Data attached to the `WOOSMAP_PRIVATE_API_KEY` will be deleted. Use an empty test project for this.
     

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The repository makes use of [Bazel](https://bazel.build/) to generate outputs fr
 
 ### Build and test
 
-1. `npm run build`
+1. `npm i`
+2. `npm run build`
 
     This generates the following outputs in the dist folder:
 
@@ -39,16 +40,18 @@ The repository makes use of [Bazel](https://bazel.build/) to generate outputs fr
     > **Note**: If a documentation item is not generated, be sure it is included
     in the appropriate index.yml file.
 
-2. `npm run build:responses` (optional)
+3. `npm run responses` (optional)
     > **Note**: This is an optional step requiring an API key. Set the `WOOSMAP_PUBLIC_API_KEY` and `WOOSMAP_PRIVATE_API_KEY` environmental variable before running. **Hint**: Use a `.bazelrc.user` file at the root of this project.
 
     > **Warning**: Data attached to the `WOOSMAP_PRIVATE_API_KEY` will be deleted. Use an empty test project for this.
     
     > **Note**: This step only needs to run when the generation code or sample requests have been updated.
 
+    > **Note**: A single response can be updated similar to `npm run responses -- --only woosmap_http_address_details`. 
+
     > `WOOSMAP_PUBLIC_API_KEY=woos-xxx WOOSMAP_PRIVATE_API_KEY=xxxx npm run build:responses`
 
-3. `npm run build:samples` (optional)
+5. `npm run samples` (optional)
 
     > **Note**: Generates snippets from requests to be integrated as xCodeSamples in path schemas.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "http-specification",
-  "version": "1.17.2",
+  "name": "openapi-specification",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "http-specification",
-      "version": "1.17.2",
+      "name": "openapi-specification",
+      "version": "1.0.0",
       "license": "Apache 2.0",
       "devDependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.9",
+        "@bazel/bazelisk": "^1.11.0",
         "@bazel/buildifier": "^4.0.1",
         "@bazel/buildozer": "^4.0.1",
         "@bazel/ibazel": "^0.15.10",
@@ -44,6 +45,7 @@
         "remark-html": "^13.0.1",
         "remark-parse": "^9.0.0",
         "remark-stringify": "^9.0.0",
+        "rimraf": "^3.0.2",
         "slugify": "^1.6.0",
         "swagger-cli": "^4.0.4",
         "tar": "^6.1.11",
@@ -298,6 +300,16 @@
         "@babel/helper-validator-identifier": "^7.12.11",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@bazel/bazelisk": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@bazel/bazelisk/-/bazelisk-1.11.0.tgz",
+      "integrity": "sha512-lxiQzVqSGDG0PIDQGJdVDjp7T+50p5NnM4EnRJa76mkZp6u5ul19GJNKhPKi81TZQALZEZDxAgxVqQKkWTUOxA==",
+      "dev": true,
+      "bin": {
+        "bazel": "bazelisk.js",
+        "bazelisk": "bazelisk.js"
       }
     },
     "node_modules/@bazel/buildifier": {
@@ -5422,11 +5434,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8078,6 +8085,12 @@
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
+    },
+    "@bazel/bazelisk": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@bazel/bazelisk/-/bazelisk-1.11.0.tgz",
+      "integrity": "sha512-lxiQzVqSGDG0PIDQGJdVDjp7T+50p5NnM4EnRJa76mkZp6u5ul19GJNKhPKi81TZQALZEZDxAgxVqQKkWTUOxA==",
+      "dev": true
     },
     "@bazel/buildifier": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "http-specification",
+  "name": "openapi-specification",
   "private": true,
-  "version": "1.17.2",
+  "version": "1.0.0",
   "homepage": "https://github.com/woosmap/openapi-specification#readme",
   "bugs": {
     "url": "https://github.com/woosmap/openapi-specification/issues"
@@ -15,10 +15,11 @@
     "dist/*.json"
   ],
   "scripts": {
-    "build": "npm run build:parameters && bazel build ... && rm -rf dist/* && tar xf bazel-bin/dist.tar -C dist",
-    "build:responses": "bazel run generator/responses:_responses_bin -- --output `pwd`/specification/responses",
-    "build:samples": "bazel run generator/requests:_samples_bin -- --output `pwd`/specification/snippets",
-    "build:parameters": "bazel build :parameters.yml && cp bazel-bin/parameters.yml specification/parameters/_index.yml",
+    "prebuild": "rimraf dist",
+    "build": "bazel build //:outputs",
+    "postbuild": "mkdir -p dist; tar xf bazel-bin/dist.tar -C dist && cp bazel-bin/parameters.yml specification/parameters/_index.yml",
+    "responses": "bazel run generator/responses:_responses_bin -- --output `pwd`/specification/responses",
+    "samples": "bazel run generator/requests:_samples_bin -- --output `pwd`/specification/snippets",
     "publish:postman": "bazel run generator/postman:_postman_bin",
     "test": "bazel test ...",
     "watch": "ibazel build ...",
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
+    "@bazel/bazelisk": "^1.11.0",
     "@bazel/buildifier": "^4.0.1",
     "@bazel/buildozer": "^4.0.1",
     "@bazel/ibazel": "^0.15.10",
@@ -60,6 +62,7 @@
     "remark-html": "^13.0.1",
     "remark-parse": "^9.0.0",
     "remark-stringify": "^9.0.0",
+    "rimraf": "^3.0.2",
     "slugify": "^1.6.0",
     "swagger-cli": "^4.0.4",
     "tar": "^6.1.11",


### PR DESCRIPTION
This change includes [@bazel/bazelisk](https://www.npmjs.com/package/@bazel/bazelisk) as a dependency and runs all build/test execution through NPM removing dependency on a local Bazel installation.

`npm i`
`npm run build`

## optional

`npm test `

Also changes the following:
[pre/post build hooks](https://docs.npmjs.com/cli/v8/using-npm/scripts#pre--post-scripts)
uses [rimraf](https://www.npmjs.com/package/rimraf) for cross platform compatibility
removes bazel cache as it is not necessary