### PR TITLE
Fix: update related postal codes type for Localities Autocomplete

### DIFF
--- a/specification/schemas/LocalitiesAutocompleteRelated.yml
+++ b/specification/schemas/LocalitiesAutocompleteRelated.yml
@@ -4,11 +4,6 @@ description: Contains a set of related elements to the locality suggestion.
 properties:
   postal_codes:
     description: Postal codes related to the locality suggestion.
-    type: object
-    properties:
-      public_id:
-        type: string
-        description: Public ID of a related Postal Code.
-      description:
-        type: string
-        description: Formated description for the related Postal Code.
+    type: array
+    items:
+      $ref: "./LocalitiesAutocompleteRelatedPostalCode.yml"

--- a/specification/schemas/LocalitiesAutocompleteRelatedPostalCode.yml
+++ b/specification/schemas/LocalitiesAutocompleteRelatedPostalCode.yml
@@ -1,0 +1,14 @@
+title: LocalitiesAutocompleteRelatedPostalCode
+type: object
+description: Contains a set of related elements to the locality suggestion.
+properties:
+  postal_codes:
+    description: Postal codes related to the locality suggestion.
+    type: object
+    properties:
+      public_id:
+        type: string
+        description: Public ID of a related Postal Code.
+      description:
+        type: string
+        description: Formated description for the related Postal Code.

--- a/specification/schemas/_index.yml
+++ b/specification/schemas/_index.yml
@@ -100,6 +100,8 @@ LocalitiesAutocompleteMatchedFields:
   $ref: "./LocalitiesAutocompleteMatchedFields.yml"
 LocalitiesAutocompleteRelated:
   $ref: "./LocalitiesAutocompleteRelated.yml"
+LocalitiesAutocompleteRelatedPostalCode:
+  $ref: "./LocalitiesAutocompleteRelatedPostalCode.yml"
 LocalitiesAutocompleteResponse:
   $ref: "./LocalitiesAutocompleteResponse.yml"
 LocalitiesDetailsPostalCodeResponse:


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

## Issue
The  `related.postal_codes` is a list of objects and was wrongly declared.

## Checklist:
<!-- Please go through this list. Don't just tick the boxes, verify each one. -->

- [x] My code follows the style guidelines for this repo
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings/errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

## Comments
<!-- Any other comments... maybe a linked PR or note to remember something -->
