### PR TITLE
fix: Set bazel version to the latest one which supports WORKSPACE

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,2 @@
+BAZELISK_BASE_URL=https://github.com/bazelbuild/bazel/releases/download
+USE_BAZEL_VERSION= 7.4.1


### PR DESCRIPTION
<!-- The title of the PR ↑↑↑ above should provide a general summary of what it is about. -->
<!-- Warning: any PR that has missing info is not ready to be reviewed. -->

## Issue
https://github.com/Woosmap/openapi-specification/issues/149

## Describe your changes
use bazeliskrc to set bazel version to the latest one which supports WORKSPACE

## How to test
`npm run build`

