### PR TITLE
chore: group npm dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Bundle all npm updates into a single grouped PR per run.
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Add a `groups` block to the npm ecosystem in `.github/dependabot.yml` that matches all packages (`"*"`), so Dependabot bundles version updates into **one grouped PR per run** instead of a separate PR per package.

## Why

We currently get a stream of individual Dependabot PRs (e.g. #203–#207). Grouping them reduces PR/CI noise and lets us review and merge dependency bumps in a single pass.

## Notes

- Applies to future runs. To regroup the existing open PRs immediately, comment `@dependabot recreate` on one of them (Dependabot will close the others into a single grouped PR), or wait for the next weekly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)